### PR TITLE
refactor: indent code and fix lint

### DIFF
--- a/crates/cli/src/domain/file/project_file.rs
+++ b/crates/cli/src/domain/file/project_file.rs
@@ -1,7 +1,7 @@
 use std::{
-    fs,
-    io::Write,
-    path::{Path, PathBuf},
+	fs,
+	io::Write,
+	path::{Path, PathBuf},
 };
 
 use crate::domain::file::project_templates::*;
@@ -9,93 +9,90 @@ use crate::domain::file::project_templates::*;
 type Result<T> = std::result::Result<T, String>;
 
 fn display<P: AsRef<Path>>(p: P) -> String {
-    p.as_ref().display().to_string()
+	p.as_ref().display().to_string()
 }
 
 pub struct ProjectFile;
 
 impl ProjectFile {
-    pub fn create_project(project_name: &str) -> Result<()> {
-        let module_dir = Self::module_dir(project_name);
-        Self::create_dir(&module_dir)?;
+	pub fn create_project(project_name: &str) -> Result<()> {
+		let module_dir = Self::module_dir(project_name);
+		Self::create_dir(&module_dir)?;
 
-        let content = ProjectTemplates::project_swift_content();
-        let file_path = module_dir.join(format!("{name}.swift", name = project_name));
-        Self::write_file(&file_path, &content)
-    }
+		let content = ProjectTemplates::project_swift_content();
+		let file_path = module_dir.join(format!("{name}.swift", name = project_name));
+		Self::write_file(&file_path, &content)
+	}
 
-    pub fn create_test_folder(project_name: &str) -> Result<()> {
-        let tests_dir = Self::tests_dir(project_name);
-        Self::create_dir(&tests_dir)?;
+	pub fn create_test_folder(project_name: &str) -> Result<()> {
+		let tests_dir = Self::tests_dir(project_name);
+		Self::create_dir(&tests_dir)?;
 
-        let content = ProjectTemplates::test_content(project_name);
-        let file_path = tests_dir.join(format!("{name}Tests.swift", name = project_name));
-        Self::write_file(&file_path, &content)
-    }
+		let content = ProjectTemplates::test_content(project_name);
+		let file_path = tests_dir.join(format!("{name}Tests.swift", name = project_name));
+		Self::write_file(&file_path, &content)
+	}
 
-    pub fn create_package(
-        project_name: &str,
-        platform: &str,
-        version: &str,
-        is_plugin: bool,
-    ) -> Result<()> {
-        let content = ProjectTemplates::package_swift_content(
-            project_name,
-            platform,
-            version,
-            is_plugin,
-        );
-        Self::create_root_file(project_name, "Package.swift", content)
-    }
+	pub fn create_package(
+		project_name: &str,
+		platform: &str,
+		version: &str,
+		is_plugin: bool,
+	) -> Result<()> {
+		let content =
+			ProjectTemplates::package_swift_content(project_name, platform, version, is_plugin);
+		Self::create_root_file(project_name, "Package.swift", content)
+	}
 
-    pub fn create_changelog(project_name: &str) -> Result<()> {
-        let content = ProjectTemplates::changelog_content();
-        Self::create_root_file(project_name, "CHANGELOG.md", content)
-    }
+	pub fn create_changelog(project_name: &str) -> Result<()> {
+		let content = ProjectTemplates::changelog_content();
+		Self::create_root_file(project_name, "CHANGELOG.md", content)
+	}
 
-    pub fn create_readme(project_name: &str) -> Result<()> {
-        let content = ProjectTemplates::readme_content(project_name);
-        Self::create_root_file(project_name, "README.md", content)
-    }
+	pub fn create_readme(project_name: &str) -> Result<()> {
+		let content = ProjectTemplates::readme_content(project_name);
+		Self::create_root_file(project_name, "README.md", content)
+	}
 
-    pub fn create_spi(project_name: &str) -> Result<()> {
-        let content = ProjectTemplates::spi_content(project_name);
-        Self::create_root_file(project_name, ".spi.yml", content)
-    }
+	pub fn create_spi(project_name: &str) -> Result<()> {
+		let content = ProjectTemplates::spi_content(project_name);
+		Self::create_root_file(project_name, ".spi.yml", content)
+	}
 
-    pub fn create_swiftlint(project_name: &str) -> Result<()> {
-        let content = ProjectTemplates::swiftlint_content();
-        Self::create_root_file(project_name, ".swiftlint.yml", content)
-    }
+	pub fn create_swiftlint(project_name: &str) -> Result<()> {
+		let content = ProjectTemplates::swiftlint_content();
+		Self::create_root_file(project_name, ".swiftlint.yml", content)
+	}
 
 	// Private
 
-    fn module_dir(project_name: &str) -> PathBuf {
-        Path::new(project_name).join("Sources").join(project_name)
-    }
+	fn module_dir(project_name: &str) -> PathBuf {
+		Path::new(project_name).join("Sources").join(project_name)
+	}
 
-    fn tests_dir(project_name: &str) -> PathBuf {
-        Path::new(project_name)
-            .join("Tests")
-            .join(format!("{name}Tests", name = project_name))
-    }
+	fn tests_dir(project_name: &str) -> PathBuf {
+		Path::new(project_name)
+			.join("Tests")
+			.join(format!("{name}Tests", name = project_name))
+	}
 
-    fn create_root_file(project_name: &str, filename: &str, content: String) -> Result<()> {
-        let root = Path::new(project_name);
-        Self::create_dir(root)?;
-        let file_path = root.join(filename);
-        Self::write_file(&file_path, &content)
-    }
+	fn create_root_file(project_name: &str, filename: &str, content: String) -> Result<()> {
+		let root = Path::new(project_name);
+		Self::create_dir(root)?;
+		let file_path = root.join(filename);
+		Self::write_file(&file_path, &content)
+	}
 
-    fn create_dir<P: AsRef<Path>>(path: P) -> Result<()> {
-        fs::create_dir_all(&path)
-            .map_err(|e| format!("Error creating directory '{}': {}", display(path), e))
-    }
+	fn create_dir<P: AsRef<Path>>(path: P) -> Result<()> {
+		fs::create_dir_all(&path)
+			.map_err(|e| format!("Error creating directory '{}': {}", display(path), e))
+	}
 
-    fn write_file<P: AsRef<Path>>(path: P, content: &str) -> Result<()> {
-        let mut file = fs::File::create(&path)
-            .map_err(|e| format!("Error creating file '{}': {}", display(&path), e))?;
-        file.write_all(content.as_bytes())
-            .map_err(|e| format!("Error writing to file '{}': {}", display(&path), e))
-    }
+	fn write_file<P: AsRef<Path>>(path: P, content: &str) -> Result<()> {
+		let mut file = fs::File::create(&path)
+			.map_err(|e| format!("Error creating file '{}': {}", display(&path), e))?;
+		file
+			.write_all(content.as_bytes())
+			.map_err(|e| format!("Error writing to file '{}': {}", display(&path), e))
+	}
 }

--- a/crates/cli/src/domain/mod.rs
+++ b/crates/cli/src/domain/mod.rs
@@ -1,4 +1,4 @@
-pub mod usecase;
 pub mod builder;
 pub mod file;
 pub mod platform;
+pub mod usecase;

--- a/crates/cli/src/domain/platform/platform_validator.rs
+++ b/crates/cli/src/domain/platform/platform_validator.rs
@@ -4,11 +4,7 @@ use std::collections::HashMap;
 pub struct PlatformValidator;
 
 impl PlatformValidator {
-	pub fn generate_platform(
-		project_name: &str, 
-		platform: Vec<&str>, 
-		is_plugin: bool
-	) {
+	pub fn generate_platform(project_name: &str, platform: Vec<&str>, is_plugin: bool) {
 		let platforms = HashMap::from([
 			("iOS", "26"),
 			("macOS", "26"),

--- a/crates/cli/src/domain/usecase/usecase.rs
+++ b/crates/cli/src/domain/usecase/usecase.rs
@@ -8,6 +8,6 @@ impl SpmUseCase {
 		selected_file: Vec<&str>,
 		platform: Vec<&str>,
 	) -> Result<(), String> {
-		SpmBuilder::builder(&project_name, selected_file, platform).await
+		SpmBuilder::builder(project_name, selected_file, platform).await
 	}
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,13 +1,13 @@
-mod presentation;
 mod domain;
+mod presentation;
 
 use presentation::cli_controller::CliController;
 use presentation::header::Header;
 
 #[tokio::main]
 async fn main() {
-    let header = Header::show();
-    println!("{header}");
+	let header = Header::show();
+	println!("{header}");
 
-    let _ = CliController::execute_flow().await;
+	let _ = CliController::execute_flow().await;
 }

--- a/crates/cli/src/presentation/cli_controller.rs
+++ b/crates/cli/src/presentation/cli_controller.rs
@@ -23,9 +23,9 @@ impl CliController {
 		SpmUseCase::execute(
 			&project_name, 
 			file_selected, 
-			vec![platform_selected]
+			vec![platform_selected],
 		).await?;
-		
+
 		Self::command_open_xcode(&project_name)?;
 		Ok(())
 	}
@@ -102,12 +102,7 @@ impl CliController {
 		Self::multiselect_options(
 			"Add files",
 			"Do you want to add some of these files?",
-			&[
-				"Changelog",
-				"Swift Package Index",
-				"Readme",
-				"SwiftLint",
-			],
+			&["Changelog", "Swift Package Index", "Readme", "SwiftLint"],
 		)
 	}
 

--- a/crates/cli/src/presentation/header.rs
+++ b/crates/cli/src/presentation/header.rs
@@ -4,26 +4,30 @@ use colored::{Color, Colorize};
 pub struct Header;
 
 impl Header {
-    const VERSION: &'static str = "0.9.0";
+	const VERSION: &'static str = "0.9.0";
 
-    pub fn show() -> String {
-        Self::check_version();
+	pub fn show() -> String {
+		Self::check_version();
 
-        let orange = Color::TrueColor { r: 240, g: 81, b: 56 };
+		let orange = Color::TrueColor {
+			r: 240,
+			g: 81,
+			b: 56,
+		};
 
-        format!(
-            "\n{}\n\
+		format!(
+			"\n{}\n\
              🚀 You can create your Swift Package via the command line 🔨\n\
              v{}\n",
-            "SPM Swift Package".color(orange),
-            Self::VERSION
-        )
-    }
+			"SPM Swift Package".color(orange),
+			Self::VERSION
+		)
+	}
 
-    fn check_version() {
-        let _ = Command::new("spm-swift-package")
-            .version(Self::VERSION)
-            .ignore_errors(true)
-            .get_matches();
-    }
+	fn check_version() {
+		let _ = Command::new("spm-swift-package")
+			.version(Self::VERSION)
+			.ignore_errors(true)
+			.get_matches();
+	}
 }

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1,5 +1,5 @@
-use xshell::{cmd, Shell};
 use demand::Input;
+use xshell::{Shell, cmd};
 
 fn main() -> anyhow::Result<()> {
 	header();
@@ -20,18 +20,18 @@ fn header() {
 
 fn input_option_validation(shell: Shell) -> anyhow::Result<()> {
 	let validation_input = |s: &str| {
-        if s.is_empty() {
-            return Err("Input cannot be empty");
-        }
+		if s.is_empty() {
+			return Err("Input cannot be empty");
+		}
 
-        Ok(())
-    };
+		Ok(())
+	};
 
-    let option_input = Input::new("Choose an option: ")
-        .prompt("Option: ")
-        .validation(validation_input);
+	let option_input = Input::new("Choose an option: ")
+		.prompt("Option: ")
+		.validation(validation_input);
 
-    let option = option_input.run().expect("error running input");
+	let option = option_input.run().expect("error running input");
 
 	match option.as_str() {
 		"1" => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Reformats CLI and xtask sources, reorders domain modules, and tidies minor function calls/signatures.
> 
> - **CLI**:
>   - Reformat/indent multiple files in `domain`, `presentation`, and `main.rs`.
>   - Reorder module exports in `domain/mod.rs` (`builder`, `file`, `platform`, `usecase`).
>   - Tidy `SpmUseCase::execute` call to pass `project_name` directly.
>   - Compact `PlatformValidator::generate_platform` signature and loop formatting.
> - **Xtask**:
>   - Reorder imports and apply minor formatting in `src/main.rs` (input validation and option handling).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e1640960b58dda8f1a8968b329660b4e64c322c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->