### PR TITLE
fix: panic input xtask

### DIFF
--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1,5 +1,7 @@
 use demand::Input;
 use xshell::{Shell, cmd};
+use std::io::ErrorKind;
+use std::process::exit;
 
 fn main() -> anyhow::Result<()> {
 	header();
@@ -27,11 +29,21 @@ fn input_option_validation(shell: Shell) -> anyhow::Result<()> {
 		Ok(())
 	};
 
-	let option_input = Input::new("Choose an option: ")
-		.prompt("Option: ")
-		.validation(validation_input);
-
-	let option = option_input.run().expect("error running input");
+	let option = loop {
+		let option_input = Input::new("Choose an option: ")
+			.prompt("Option: ")
+			.validation(validation_input);
+		match option_input.run() {
+			Ok(opt) => break opt,
+			Err(e) => {
+				if e.kind() == ErrorKind::Interrupted {
+					exit(0);
+				}
+				eprintln!("error running input: {e}");
+				return Err(e.into());
+			}
+		}
+	};
 
 	match option.as_str() {
 		"1" => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make the xtask prompt resilient by looping input, exiting cleanly on interruption, and returning errors instead of panicking.
> 
> - **xtask CLI (`crates/xtask/src/main.rs`)**:
>   - **Input Handling**: Wrap option prompt in a loop; on `ErrorKind::Interrupted` exit with code `0`; on other errors, log and return the error.
>   - **Imports**: Add `std::io::ErrorKind` and `std::process::exit` to support graceful handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f0e829579c6012e0353c7fbfcf9f5732b6685fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->