### PR TITLE
feat: add rust docs

### DIFF
--- a/crates/cli/src/domain/builder/spm_builder.rs
+++ b/crates/cli/src/domain/builder/spm_builder.rs
@@ -1,9 +1,11 @@
 use crate::domain::file::project_file::*;
 use crate::domain::platform::platform_validator::*;
 
+/// Handles the creation of all project components based on selected options
 pub struct SpmBuilder;
 
 impl SpmBuilder {
+	/// Builds the project structure, templates, and optional configuration files
 	pub async fn builder(
 		project_name: &str,
 		selected_file: Vec<&str>,
@@ -22,6 +24,7 @@ impl SpmBuilder {
 		Self::validate_selected_file(project_name, selected_file).await
 	}
 
+	/// Validates which optional files must be generated based on user selection
 	async fn validate_selected_file(
 		project_name: &str,
 		selected_file: Vec<&str>,

--- a/crates/cli/src/domain/file/project_file.rs
+++ b/crates/cli/src/domain/file/project_file.rs
@@ -6,15 +6,19 @@ use std::{
 
 use crate::domain::file::project_templates::*;
 
+/// Convenience alias for results that return a String error
 type Result<T> = std::result::Result<T, String>;
 
+/// Converts a path into a displayable String
 fn display<P: AsRef<Path>>(p: P) -> String {
 	p.as_ref().display().to_string()
 }
 
+/// Handles creation of all project files and folders
 pub struct ProjectFile;
 
 impl ProjectFile {
+	/// Creates the main Swift module directory and source file
 	pub fn create_project(project_name: &str) -> Result<()> {
 		let module_dir = Self::module_dir(project_name);
 		Self::create_dir(&module_dir)?;
@@ -24,6 +28,7 @@ impl ProjectFile {
 		Self::write_file(&file_path, &content)
 	}
 
+	/// Creates the tests folder and the main test file
 	pub fn create_test_folder(project_name: &str) -> Result<()> {
 		let tests_dir = Self::tests_dir(project_name);
 		Self::create_dir(&tests_dir)?;
@@ -33,6 +38,7 @@ impl ProjectFile {
 		Self::write_file(&file_path, &content)
 	}
 
+	/// Creates the Package.swift file with the configured template
 	pub fn create_package(
 		project_name: &str,
 		platform: &str,
@@ -44,38 +50,45 @@ impl ProjectFile {
 		Self::create_root_file(project_name, "Package.swift", content)
 	}
 
+	/// Creates the CHANGELOG.md file in the project root
 	pub fn create_changelog(project_name: &str) -> Result<()> {
 		let content = ProjectTemplates::changelog_content();
 		Self::create_root_file(project_name, "CHANGELOG.md", content)
 	}
 
+	/// Creates the README.md file in the project root
 	pub fn create_readme(project_name: &str) -> Result<()> {
 		let content = ProjectTemplates::readme_content(project_name);
 		Self::create_root_file(project_name, "README.md", content)
 	}
 
+	/// Creates the .spi.yml file used by Swift Package Index
 	pub fn create_spi(project_name: &str) -> Result<()> {
 		let content = ProjectTemplates::spi_content(project_name);
 		Self::create_root_file(project_name, ".spi.yml", content)
 	}
 
+	/// Creates the .swiftlint.yml configuration file
 	pub fn create_swiftlint(project_name: &str) -> Result<()> {
 		let content = ProjectTemplates::swiftlint_content();
 		Self::create_root_file(project_name, ".swiftlint.yml", content)
 	}
 
-	// Private
+	/// Private methods
 
+	/// Returns the path for the module Sources directory
 	fn module_dir(project_name: &str) -> PathBuf {
 		Path::new(project_name).join("Sources").join(project_name)
 	}
 
+	/// Returns the path for the Tests directory of the project
 	fn tests_dir(project_name: &str) -> PathBuf {
 		Path::new(project_name)
 			.join("Tests")
 			.join(format!("{name}Tests", name = project_name))
 	}
 
+	/// Creates a file in the project root with the given content
 	fn create_root_file(project_name: &str, filename: &str, content: String) -> Result<()> {
 		let root = Path::new(project_name);
 		Self::create_dir(root)?;
@@ -83,11 +96,13 @@ impl ProjectFile {
 		Self::write_file(&file_path, &content)
 	}
 
+	/// Creates a directory and all missing parent directories
 	fn create_dir<P: AsRef<Path>>(path: P) -> Result<()> {
 		fs::create_dir_all(&path)
 			.map_err(|e| format!("Error creating directory '{}': {}", display(path), e))
 	}
 
+	/// Writes content to a file, overwriting any existing content
 	fn write_file<P: AsRef<Path>>(path: P, content: &str) -> Result<()> {
 		let mut file = fs::File::create(&path)
 			.map_err(|e| format!("Error creating file '{}': {}", display(&path), e))?;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -6,24 +6,34 @@ use clap::{Parser, Subcommand};
 use presentation::cli_controller::CliController;
 use presentation::header::Header;
 
+/// Defines the CLI arguments accepted by the application
+/// Uses Clap to support a subcommand-based interface
 #[derive(Parser)]
 struct Args {
+	/// Optional subcommand that defines an alternative execution flow
 	#[command(subcommand)]
 	command: Option<Command>,
 }
 
+/// Represents the available CLI subcommands
+/// UI triggers the graphical mode instead of the terminal flow
 #[derive(Subcommand)]
 enum Command {
+	/// Runs the UI mode using the iced-based interface
 	UI,
 }
 
+/// Entry point of the application
+/// Uses Tokio runtime to support async operations in the CLI flow
 #[tokio::main]
 async fn main() {
 	let args = Args::parse();
 
 	if let Some(Command::UI) = args.command {
+		// Runs the visual interface instead of the terminal builder
 		let _ = ui::spm_view::run();
 	} else {
+		// Prints the header banner and runs the interactive CLI flow
 		let header = Header::show();
 		println!("{header}");
 

--- a/crates/cli/src/presentation/cli_controller.rs
+++ b/crates/cli/src/presentation/cli_controller.rs
@@ -4,9 +4,11 @@ use std::process::Command;
 
 use crate::domain::builder::spm_builder::*;
 
+/// Controls all CLI interactions and orchestrates the project creation flow
 pub struct CliController;
 
 impl CliController {
+	/// Executes the complete flow: prompts user input, builds the project, and opens it in Xcode
 	pub async fn execute_flow() -> Result<(), String> {
 		let project_name = Self::project_name_input()?;
 		let file_selected = Self::multiselect_files()?;
@@ -21,6 +23,8 @@ impl CliController {
 
 	// Internal functions
 
+	/// Prompts the user to input the library or module name
+	/// Validates that the name is not empty
 	fn project_name_input() -> Result<String, String> {
 		let validation_empty = |s: &str| {
 			if s.is_empty() {
@@ -37,13 +41,15 @@ impl CliController {
 
 		input.run().map_err(|e| {
 			if e.kind() == std::io::ErrorKind::Interrupted {
-				"Operation interrupted by user.".to_string()
+				"Operation interrupted by user".to_string()
 			} else {
 				format!("Error getting library name: {}", e)
 			}
 		})
 	}
 
+	/// Creates a generic multiselect component with a prompt, description, and list of options
+	/// Ensures at least one option is selected before continuing
 	fn multiselect_options(
 		prompt: &str,
 		description: &str,
@@ -62,7 +68,7 @@ impl CliController {
 				Ok(selection) => selection,
 				Err(e) => {
 					if e.kind() == std::io::ErrorKind::Interrupted {
-						return Err("Operation interrupted by user.".to_string());
+						return Err("Operation interrupted by user".to_string());
 					} else {
 						return Err(format!("Error selecting options: {}", e));
 					}
@@ -87,6 +93,7 @@ impl CliController {
 		}
 	}
 
+	/// Defines the file options available for selection (Changelog, SPI, README, SwiftLint)
 	fn multiselect_files() -> Result<Vec<&'static str>, String> {
 		Self::multiselect_options(
 			"Add files",
@@ -95,6 +102,8 @@ impl CliController {
 		)
 	}
 
+	/// Displays a select input for platform choice
+	/// The result is always a single selected platform
 	fn select_platform() -> Result<&'static str, String> {
 		let mut select = Select::new("Choose platform")
 			.description("Which platform do you want to choose?")
@@ -106,13 +115,15 @@ impl CliController {
 
 		select.run().map_err(|e| {
 			if e.kind() == std::io::ErrorKind::Interrupted {
-				"Operation interrupted by user.".to_string()
+				"Operation interrupted by user".to_string()
 			} else {
 				format!("Error selecting platform: {}", e)
 			}
 		})
 	}
 
+	/// Shows a loading spinner while running a simulated build step
+	/// Uses a 5 second delay for effect
 	async fn loading() -> Result<(), String> {
 		Spinner::new("Building the Package...")
 			.style(&SpinnerStyle::line())
@@ -122,6 +133,8 @@ impl CliController {
 			.map_err(|_| "Error running spinner".to_string())
 	}
 
+	/// Opens the generated Package.swift in Xcode using a shell command
+	/// Changes directory into the created project before launching Xcode
 	fn command_open_xcode(project_name: &str) -> Result<(), String> {
 		let command = format!("cd {} && open Package.swift", project_name);
 		let mut child = Command::new("sh")

--- a/crates/xtask/src/xtask_command.rs
+++ b/crates/xtask/src/xtask_command.rs
@@ -36,7 +36,7 @@ impl XtaskCommand {
 				cmd!(shell, "cargo publish --dry-run").run()?;
 			}
 			XtaskCommand::PrepareHomebrew => {
-				cmd!(shell, "releasor --file-name spm-swift-package").run()?;
+				cmd!(shell, "releasor -f spm-swift-package").run()?;
 			}
 		}
 

--- a/mise.toml
+++ b/mise.toml
@@ -44,4 +44,4 @@ run = "cargo publish"
 
 [tasks.releasor]
 description = "Generate .tar.gz release artifacts using releasor"
-run = "releasor --file-name spm-swift-package"
+run = "releasor -f spm-swift-package"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds Rustdoc across CLI modules, normalizes interruption messages, and switches releasor to the short -f flag in tooling.
> 
> - **Documentation**:
>   - Add Rustdoc comments to `crates/cli/src/domain/builder/spm_builder.rs`, `crates/cli/src/domain/file/project_file.rs`, `crates/cli/src/presentation/cli_controller.rs`, and `crates/cli/src/main.rs`.
> - **CLI UX**:
>   - Normalize interruption error messages by removing trailing periods in `cli_controller.rs`.
> - **Tooling**:
>   - Update releasor invocation to use short flag `-f` in `crates/xtask/src/xtask_command.rs` and `mise.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f50fd1d19c634d9a3aa03a579970b34275a85de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->