### PR TITLE
chore(deps): update iced to 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
 
 [[package]]
@@ -624,7 +624,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.2",
+ "unicode-width",
  "windows-sys 0.61.2",
 ]
 
@@ -750,7 +750,8 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "cryoglyph"
 version = "0.1.0"
-source = "git+https://github.com/iced-rs/cryoglyph.git?rev=99b46959369f38a06c11353bf1be81d383b289fc#99b46959369f38a06c11353bf1be81d383b289fc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08bc795bdbccdbd461736fb163930a009da6597b226d6f6fce33e7a8eb6ec519"
 dependencies = [
  "cosmic-text",
  "etagere",
@@ -826,8 +827,9 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
-version = "0.1.1"
-source = "git+https://github.com/iced-rs/winit.git?rev=05b8ff17a06562f0a10bb46e6eaacbe2a95cb5ed#05b8ff17a06562f0a10bb46e6eaacbe2a95cb5ed"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "either"
@@ -1315,8 +1317,9 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "iced"
-version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?branch=master#3fc85b900d9041ab2c1b41de6e0c26470233c32e"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "000e01026c93ba643f8357a3db3ada0e6555265a377f6f9291c472f6dd701fb3"
 dependencies = [
  "iced_core",
  "iced_debug",
@@ -1330,8 +1333,9 @@ dependencies = [
 
 [[package]]
 name = "iced_core"
-version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?branch=master#3fc85b900d9041ab2c1b41de6e0c26470233c32e"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ab1937d699403e7e69252ae743a902bcee9f4ab2052cc4c9a46fcf34729d85"
 dependencies = [
  "bitflags 2.10.0",
  "bytes",
@@ -1347,8 +1351,9 @@ dependencies = [
 
 [[package]]
 name = "iced_debug"
-version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?branch=master#3fc85b900d9041ab2c1b41de6e0c26470233c32e"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25035ab0215a620e53f4103e36fc4e59a1fb2817e4bfc38a30ad27b4202ea0be"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -1357,8 +1362,9 @@ dependencies = [
 
 [[package]]
 name = "iced_futures"
-version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?branch=master#3fc85b900d9041ab2c1b41de6e0c26470233c32e"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c0c85ccad42dfbec7293c36c018af0ea0dbcc52d137a4a9a0b0f6822a3fdf0a"
 dependencies = [
  "futures",
  "iced_core",
@@ -1370,8 +1376,9 @@ dependencies = [
 
 [[package]]
 name = "iced_graphics"
-version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?branch=master#3fc85b900d9041ab2c1b41de6e0c26470233c32e"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234ca1c2cec4155055f68fa5fad1b5242c496ac8238d80a259bca382fb44a102"
 dependencies = [
  "bitflags 2.10.0",
  "bytemuck",
@@ -1388,8 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "iced_program"
-version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?branch=master#3fc85b900d9041ab2c1b41de6e0c26470233c32e"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dfafec2947cda688d8eb00dac337ba11aa60f9ef6335aed343e189d26e4a673"
 dependencies = [
  "iced_graphics",
  "iced_runtime",
@@ -1397,8 +1405,9 @@ dependencies = [
 
 [[package]]
 name = "iced_renderer"
-version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?branch=master#3fc85b900d9041ab2c1b41de6e0c26470233c32e"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250cc0802408e8c077986ec56c7d07c65f423ee658a4b9fd795a1f2aae5dac05"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -1409,8 +1418,9 @@ dependencies = [
 
 [[package]]
 name = "iced_runtime"
-version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?branch=master#3fc85b900d9041ab2c1b41de6e0c26470233c32e"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1889b819ce4c06674183242e336c8d49465665441396914dc07cc86f44fa8d4"
 dependencies = [
  "bytes",
  "iced_core",
@@ -1421,8 +1431,9 @@ dependencies = [
 
 [[package]]
 name = "iced_tiny_skia"
-version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?branch=master#3fc85b900d9041ab2c1b41de6e0c26470233c32e"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe0acf8b75a3bc914aff5f2329fdffc1b36eeaea29dda0e4bd232f1c62e9cc3d"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -1437,8 +1448,9 @@ dependencies = [
 
 [[package]]
 name = "iced_wgpu"
-version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?branch=master#3fc85b900d9041ab2c1b41de6e0c26470233c32e"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff144a999b0ca0f8a10257934500060240825c42e950ec0ebee9c8ae30561c13"
 dependencies = [
  "bitflags 2.10.0",
  "bytemuck",
@@ -1456,8 +1468,9 @@ dependencies = [
 
 [[package]]
 name = "iced_widget"
-version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?branch=master#3fc85b900d9041ab2c1b41de6e0c26470233c32e"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86f6948998a5e031849afae1bb852f3b100c71572befa0be70b19075dcb2163"
 dependencies = [
  "iced_renderer",
  "log",
@@ -1469,8 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "iced_winit"
-version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?branch=master#3fc85b900d9041ab2c1b41de6e0c26470233c32e"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b7dbedc47562d1de3b9707d939f678b88c382004b7ab5a18f7a7dd723162d75"
 dependencies = [
  "iced_debug",
  "iced_program",
@@ -3153,12 +3167,6 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
@@ -4041,8 +4049,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winit"
-version = "0.30.8"
-source = "git+https://github.com/iced-rs/winit.git?rev=05b8ff17a06562f0a10bb46e6eaacbe2a95cb5ed#05b8ff17a06562f0a10bb46e6eaacbe2a95cb5ed"
+version = "0.30.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66d4b9ed69c4009f6321f762d6e61ad8a2389cd431b97cb1e146812e9e6c732"
 dependencies = [
  "ahash",
  "android-activity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ xshell = "0.2.7"
 anyhow = "1.0.100"
 tokio = { version = "1.48.0", features = ["full"] }
 insta = "1.43.2"
-iced = { git = "https://github.com/iced-rs/iced.git", branch = "master" }
+iced = "0.14.0"
 
 [profile.release]
 strip = true

--- a/crates/cli/src/domain/file/project_templates.rs
+++ b/crates/cli/src/domain/file/project_templates.rs
@@ -1,6 +1,10 @@
+/// Provides template generators for all project files
+/// Each method returns the content of a specific file as a String
 pub struct ProjectTemplates;
 
 impl ProjectTemplates {
+	/// Returns the default Swift source file template
+	/// Used to generate the main `{name}.swift` file inside Sources
 	pub fn project_swift_content() -> String {
 		r#"// The Swift Programming Language
 // https://docs.swift.org/swift-book/
@@ -8,6 +12,8 @@ impl ProjectTemplates {
 		.to_string()
 	}
 
+	/// Returns the default XCTest file template
+	/// Includes boilerplate test structure for `{project_name}Tests.swift`
 	pub fn test_content(project_name: &str) -> String {
 		format!(
 			r#"import XCTest
@@ -27,6 +33,13 @@ final class {}Tests: XCTestCase {{
 		)
 	}
 
+	/// Returns the Package.swift template
+	/// Supports two variants: plugin-enabled or standard package
+	///
+	/// * `project_name` - name of the Swift package
+	/// * `platform` - selected platform such as iOS or macOS
+	/// * `version` - minimum deployment version
+	/// * `is_plugin` - adds SwiftLint plugin configuration when true
 	pub fn package_swift_content(
 		project_name: &str,
 		platform: &str,
@@ -122,6 +135,8 @@ let package = Package(
 		}
 	}
 
+	/// Returns the default CHANGELOG.md template
+	/// Used when the Changelog option is selected
 	pub fn changelog_content() -> String {
 		r#"# CHANGELOG
 
@@ -133,6 +148,8 @@ let package = Package(
 		.to_string()
 	}
 
+	/// Returns the README.md template
+	/// Includes only the project title by default
 	pub fn readme_content(project_name: &str) -> String {
 		format!(
 			r#"# {}
@@ -141,6 +158,8 @@ let package = Package(
 		)
 	}
 
+	/// Returns the .spi.yml template for Swift Package Index configuration
+	/// Defines documentation targets and scheme attributes
 	pub fn spi_content(project_name: &str) -> String {
 		format!(
 			r#"version: 1
@@ -153,6 +172,8 @@ builder:
 		)
 	}
 
+	/// Returns a default SwiftLint configuration template
+	/// Includes baseline rules, opt-in rules, and excluded directories
 	pub fn swiftlint_content() -> String {
 		r#"disabled_rules:
   - trailing_whitespace

--- a/crates/cli/src/domain/platform/platform_validator.rs
+++ b/crates/cli/src/domain/platform/platform_validator.rs
@@ -1,9 +1,17 @@
 use crate::domain::file::project_file::*;
 use std::collections::HashMap;
 
+/// Validates and generates the appropriate platform configuration
+/// Responsible for creating the Package.swift file using the selected platform
 pub struct PlatformValidator;
 
 impl PlatformValidator {
+	/// Generates the platform configuration for the project
+	/// Creates a Package.swift file based on the selected platform and plugin flag
+	///
+	/// * `project_name` - name of the generated Swift package
+	/// * `platform` - vector containing the selected platform
+	/// * `is_plugin` - indicates whether the package is a Swift plugin
 	pub fn generate_platform(project_name: &str, platform: Vec<&str>, is_plugin: bool) {
 		let platforms = HashMap::from([
 			("iOS", "26"),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches `iced` and related crates to released 0.14 from crates.io (removing git sources) and updates `winit`/`dpi`, plus minor doc comments in CLI templates/validator.
> 
> - **Dependencies**:
>   - Migrate `iced` ecosystem to released crates.io versions: `iced`, `iced_core`, `iced_futures`, `iced_graphics`, `iced_program`, `iced_renderer`, `iced_runtime`, `iced_tiny_skia`, `iced_wgpu`, `iced_winit`, `iced_widget` (0.14.x).
>   - Replace git sources with registry for `cryoglyph` and `dpi`; bump `dpi` to `0.1.2` and `winit` to `0.30.12`.
>   - Normalize `unicode-width` dependency to a single version.
>   - Update `Cargo.toml` to use `iced = "0.14.0"`.
> - **CLI**:
>   - Add documentation comments to `crates/cli/src/domain/file/project_templates.rs` and `crates/cli/src/domain/platform/platform_validator.rs` (no functional changes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5921627e9e359ccc644f56a8ba74b4884c896ae2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->