### PR TITLE
refactor: taking version direct cargo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ readme = "README.md"
 repository = "https://github.com/heroesofcode/spm-swift-package"
 
 [workspace.dependencies]
-demand = "1.7.2"
+demand = "1.8.0"
 clap = { version = "4.5.53", features = ["derive"] }
 colored = "3.0.0"
 xshell = "0.2.7"
 anyhow = "1.0.100"
 tokio = { version = "1.48.0", features = ["full"] }
-insta = "1.43.2"
+insta = "1.44.3"
 iced = "0.14.0"
 
 [profile.release]

--- a/crates/cli/src/presentation/header.rs
+++ b/crates/cli/src/presentation/header.rs
@@ -1,11 +1,11 @@
 use clap::Command;
 use colored::{Color, Colorize};
 
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 pub struct Header;
 
 impl Header {
-	const VERSION: &'static str = "0.10.0";
-
 	pub fn show() -> String {
 		Self::check_version();
 
@@ -20,13 +20,13 @@ impl Header {
              🚀 You can create your Swift Package via the command line 🔨\n\
              v{}\n",
 			"SPM Swift Package".color(orange),
-			Self::VERSION
+			VERSION
 		)
 	}
 
 	fn check_version() {
 		let _ = Command::new("spm-swift-package")
-			.version(Self::VERSION)
+			.version(VERSION)
 			.ignore_errors(true)
 			.get_matches();
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Header now reads version from Cargo’s CARGO_PKG_VERSION; bumps `demand` and `insta` versions.
> 
> - **CLI**
>   - **Version sourcing**: Replace hardcoded `Header::VERSION` with `pub const VERSION: &str = env!("CARGO_PKG_VERSION");` and use it in `Header::show` and `check_version`.
> - **Dependencies**
>   - Bump `demand` to `1.8.0`.
>   - Bump `insta` to `1.44.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95b374c77d5dbd2a3ce01b7d47eb9804db22b9c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->