### PR TITLE
chore: release v0.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # CHANGELOG
 
+## [0.13.3] - 2026-06-25
+
+### Refactor
+
+- Simplify doc comments and optional file dispatch ([#301](https://github.com/heroesofcode/spm-swift-package/pull/301))
+- Setup SpmError type and improving code ([#299](https://github.com/heroesofcode/spm-swift-package/pull/299))
+
+### Testing
+
+- Migrate project_templates_tests to insta snapshot testing ([#297](https://github.com/heroesofcode/spm-swift-package/pull/297))
+
+### Ci
+
+- Add Markdown linting step to CI workflow ([#296](https://github.com/heroesofcode/spm-swift-package/pull/296))
+
+
+
 ## [0.13.2] - 2026-04-02
 
 ### Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3076,7 +3076,7 @@ dependencies = [
 
 [[package]]
 name = "spm-swift-package"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.13.2"
+version = "0.13.3"
 edition = "2024"
 license = "MIT"
 authors = ["João Lucas <joaolucasfp2001@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `spm-swift-package`: 0.13.2 -> 0.13.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.13.3] - 2026-06-25

### Refactor

- Simplify doc comments and optional file dispatch ([#301](https://github.com/heroesofcode/spm-swift-package/pull/301))
- Setup SpmError type and improving code ([#299](https://github.com/heroesofcode/spm-swift-package/pull/299))

### Testing

- Migrate project_templates_tests to insta snapshot testing ([#297](https://github.com/heroesofcode/spm-swift-package/pull/297))

### Ci

- Add Markdown linting step to CI workflow ([#296](https://github.com/heroesofcode/spm-swift-package/pull/296))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).