### PR TITLE
ci: add Markdown linting step to CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,6 +16,9 @@ jobs:
 
       - uses: Swatinem/rust-cache@f51f967e158417aafa338a1e46ab22095f07aa01
 
+      - name: Lint Markdown files
+        uses: rvben/rumdl@6540b53fa24e83f9693e36889e0f9c765aa90349
+
       - name: Read Xcode version
         id: xcode_version
         run: echo "XCODE_VERSION=$(cat .xcode-version)" >> $GITHUB_ENV

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -1,6 +1,6 @@
 [global]
-disable = ["MD024"]
+disable = ["MD024", "MD033", "MD041"]
+exclude = ["CHANGELOG.md", ".claude", "CLAUDE.md"]
 
 [MD013]
-code-block-line-length = 120
 line-length = 100

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 <p align="center">
   <img src="https://raw.githubusercontent.com/heroesofcode/spm-swift-package/refs/heads/main/assets/icon.webp" width="300" />
   <br>
- 
+
   <a href="https://crates.io/crates/spm-swift-package">
     <img src="https://img.shields.io/crates/v/spm-swift-package?style=for-the-badge&labelColor=1C2C2E&color=C96329&logo=Rust&logoColor=white" /></a>
-    
+
   <a href="https://github.com/heroesofcode/spm-swift-package/actions/workflows/CI.yml">
     <img src="https://img.shields.io/github/actions/workflow/status/heroesofcode/spm-swift-package/CI.yml?style=for-the-badge&labelColor=1C2C2E&label=CI&color=BEC5C9&logo=GitHub%20Actions&logoColor=BEC5C9" /></a>
-        
+
   <a href="https://github.com/heroesofcode/spm-swift-package/blob/main/LICENSE">
     <img src="https://img.shields.io/badge/license-MIT-BEC5C9?style=for-the-badge&labelColor=1C2C2E&logoColor=BEC5C9" /></a>
 </p>
@@ -17,23 +17,26 @@
 </p>
 
 ## Features
+
 - 🚀 **Multi-platform:** iOS • macOS • tvOS • watchOS • visionOS  
 - 🛠️ **Auto-generated files:** Changelog • Readme • Swift Package Index • SwiftLint  
 - ✅ **SwiftLint integration:** Generates `.swiftlint.yml` using the [SwiftLintPlugin](https://github.com/lukepistrol/SwiftLintPlugin)  
 - 🧰 **Modern toolchain:** Compatible with Xcode 26.0  
 - ⚠️ **No legacy support:** Does not work with older Xcode versions  
-- 🖥️ **GUI support:** Optional graphical interface built with [Iced](https://github.com/iced-rs/iced), launched via `spm-swift-package ui`
+- 🖥️ **GUI support:** Optional graphical interface via [Iced](https://github.com/iced-rs/iced)
 
 ## Installing
 
-#### Cargo 🦀
+### Cargo 🦀
+
 Installing from [crates.io](https://crates.io/) (requires Rust/Cargo):
 
 ```shell
 cargo install spm-swift-package
 ```
 
-#### Homebrew 🍻
+### Homebrew 🍻
+
 You can install with [Homebrew](https://brew.sh/):
 
 ```shell
@@ -43,7 +46,7 @@ brew install heroesofcode/taps/spm-swift-package
 
 ## Usage
 
-#### Run CLI
+### Run CLI
 
 ```sh
 spm-swift-package
@@ -102,7 +105,8 @@ And from here you can continue working on your SPM project 🚀 🙂 👨‍💻
 
 ## Contributing
 
-To contribute, just fork this project and then open a pull request, feel free to contribute, bring ideas and raise any problem in the issue tab.
+To contribute, fork this project and open a pull request. Feel free to bring ideas and raise any
+problem in the issue tab.
 
 ## License
 


### PR DESCRIPTION
## ✨ Summary

- add `rumdl` Markdown linting step to CI workflow
- update `.rumdl.toml` to disable `MD033` and `MD041` rules and exclude `CHANGELOG.md`, `.claude`, and `CLAUDE.md` from linting
- fix trailing whitespace and heading levels in `README.md`
- clean up contributing section wording in `README.md`

## 🔧 Type of Change

- [x] ✨ Enhancement
- [ ] 🐞 Bug fix
- [ ] 🔐 Security fix
- [ ] 💥 Breaking change
- [ ] 🚀 New feature
- [ ] 📦 New release
- [x] 📚 Documentation
- [ ] ♻️ Refactor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a CI-only Markdown lint step plus minor documentation formatting tweaks; no runtime or build logic is changed.
> 
> **Overview**
> Adds a `rumdl` Markdown lint step to the GitHub Actions CI workflow.
> 
> Updates `.rumdl.toml` to disable additional rules (`MD033`, `MD041`) and exclude `CHANGELOG.md`, `.claude`, and `CLAUDE.md` from linting. Cleans up `README.md` Markdown (heading levels/whitespace) and lightly rewords the contributing section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b9d7ac8889592c383f9bce68f91ba03ec153ee9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->