### PR TITLE
test: migrate project_templates_tests to insta snapshot testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -132,7 +132,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -601,7 +601,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -912,7 +912,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1581,6 +1581,18 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console",
+ "once_cell",
+ "similar",
+ "tempfile",
 ]
 
 [[package]]
@@ -2388,7 +2400,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2729,7 +2741,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2902,6 +2914,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "skrifa"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3011,7 +3029,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3062,6 +3080,7 @@ dependencies = [
  "colored",
  "demand",
  "iced",
+ "insta",
  "tokio",
  "xx",
 ]
@@ -3131,7 +3150,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3900,7 +3919,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = "1.0.100"
 tokio = { version = "1.48.0", features = ["full"] }
 iced = "0.14.0"
 xx = "2.3.1"
+insta = "1.47.2"
 
 [profile.release]
 strip = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -17,3 +17,6 @@ tokio.workspace = true
 iced.workspace = true
 xx.workspace = true
 
+[dev-dependencies]
+insta.workspace = true
+

--- a/crates/cli/tests/project_templates_tests.rs
+++ b/crates/cli/tests/project_templates_tests.rs
@@ -2,70 +2,49 @@ use spm_swift_package::core::file::project_templates::ProjectTemplates;
 
 #[test]
 fn test_project_swift_content() {
-	let content = ProjectTemplates::project_swift_content();
-	assert!(content.contains("The Swift Programming Language"));
-	assert!(content.contains("https://docs.swift.org/swift-book/"));
+	insta::assert_snapshot!(ProjectTemplates::project_swift_content());
 }
 
 #[test]
 fn test_xctest_content() {
-	let content = ProjectTemplates::test_content("MyLib", "XCTest");
-	assert!(content.contains("import XCTest"));
-	assert!(content.contains("@testable import MyLib"));
-	assert!(content.contains("final class MyLibTests: XCTestCase"));
-	assert!(content.contains("func testExample()"));
+	insta::assert_snapshot!(ProjectTemplates::test_content("MyLib", "XCTest"));
 }
 
 #[test]
 fn test_swift_testing_content() {
-	let content = ProjectTemplates::test_content("MyLib", "Swift Testing");
-	assert!(content.contains("import Testing"));
-	assert!(content.contains("@testable import MyLib"));
-	assert!(content.contains("@Test func example()"));
+	insta::assert_snapshot!(ProjectTemplates::test_content("MyLib", "Swift Testing"));
 }
 
 #[test]
 fn test_package_swift_without_plugin() {
-	let content = ProjectTemplates::package_swift_content("TestPkg", "iOS", "26", false);
-	assert!(content.contains("swift-tools-version: 6.2"));
-	assert!(content.contains("name: \"TestPkg\""));
-	assert!(content.contains(".iOS(.v26)"));
-	assert!(!content.contains("SwiftLintPlugin"));
+	insta::assert_snapshot!(ProjectTemplates::package_swift_content(
+		"TestPkg", "iOS", "26", false
+	));
 }
 
 #[test]
 fn test_package_swift_with_plugin() {
-	let content = ProjectTemplates::package_swift_content("TestPkg", "macOS", "26", true);
-	assert!(content.contains("SwiftLintPlugin"));
-	assert!(content.contains("dependencies:"));
-	assert!(content.contains("plugins:"));
+	insta::assert_snapshot!(ProjectTemplates::package_swift_content(
+		"TestPkg", "macOS", "26", true
+	));
 }
 
 #[test]
 fn test_changelog_content() {
-	let content = ProjectTemplates::changelog_content();
-	assert!(content.contains("# CHANGELOG"));
-	assert!(content.contains("Version 1.0.0"));
+	insta::assert_snapshot!(ProjectTemplates::changelog_content());
 }
 
 #[test]
 fn test_readme_content() {
-	let content = ProjectTemplates::readme_content("MyProject");
-	assert!(content.contains("# MyProject"));
+	insta::assert_snapshot!(ProjectTemplates::readme_content("MyProject"));
 }
 
 #[test]
 fn test_spi_content() {
-	let content = ProjectTemplates::spi_content("MyLib");
-	assert!(content.contains("version: 1"));
-	assert!(content.contains("documentation_targets: [MyLib]"));
-	assert!(content.contains("scheme: MyLib"));
+	insta::assert_snapshot!(ProjectTemplates::spi_content("MyLib"));
 }
 
 #[test]
 fn test_swiftlint_content() {
-	let content = ProjectTemplates::swiftlint_content();
-	assert!(content.contains("disabled_rules:"));
-	assert!(content.contains("opt_in_rules:"));
-	assert!(content.contains("excluded:"));
+	insta::assert_snapshot!(ProjectTemplates::swiftlint_content());
 }

--- a/crates/cli/tests/snapshots/project_templates_tests__changelog_content.snap
+++ b/crates/cli/tests/snapshots/project_templates_tests__changelog_content.snap
@@ -1,0 +1,10 @@
+---
+source: crates/cli/tests/project_templates_tests.rs
+expression: "ProjectTemplates::changelog_content()"
+---
+# CHANGELOG
+
+## Version 1.0.0
+**2024-01-18**
+
+- First release

--- a/crates/cli/tests/snapshots/project_templates_tests__package_swift_with_plugin.snap
+++ b/crates/cli/tests/snapshots/project_templates_tests__package_swift_with_plugin.snap
@@ -1,0 +1,39 @@
+---
+source: crates/cli/tests/project_templates_tests.rs
+expression: "ProjectTemplates::package_swift_content(\"TestPkg\", \"macOS\", \"26\", true)"
+---
+// swift-tools-version: 6.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "TestPkg",
+    platforms: [
+        .macOS(.v26)
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "TestPkg",
+            targets: ["TestPkg"]
+        ),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/lukepistrol/SwiftLintPlugin", exact: "0.63.1")
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "TestPkg",
+            plugins: [
+                .plugin(name: "SwiftLint", package: "SwiftLintPlugin")
+            ]
+        ),
+        .testTarget(
+            name: "TestPkgTests",
+            dependencies: ["TestPkg"]
+        ),
+    ]
+)

--- a/crates/cli/tests/snapshots/project_templates_tests__package_swift_without_plugin.snap
+++ b/crates/cli/tests/snapshots/project_templates_tests__package_swift_without_plugin.snap
@@ -1,0 +1,33 @@
+---
+source: crates/cli/tests/project_templates_tests.rs
+expression: "ProjectTemplates::package_swift_content(\"TestPkg\", \"iOS\", \"26\", false)"
+---
+// swift-tools-version: 6.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "TestPkg",
+    platforms: [
+        .iOS(.v26)
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "TestPkg",
+            targets: ["TestPkg"]
+        ),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "TestPkg",
+        ),
+        .testTarget(
+            name: "TestPkgTests",
+            dependencies: ["TestPkg"]
+        ),
+    ]
+)

--- a/crates/cli/tests/snapshots/project_templates_tests__project_swift_content.snap
+++ b/crates/cli/tests/snapshots/project_templates_tests__project_swift_content.snap
@@ -1,0 +1,6 @@
+---
+source: crates/cli/tests/project_templates_tests.rs
+expression: "ProjectTemplates::project_swift_content()"
+---
+// The Swift Programming Language
+// https://docs.swift.org/swift-book/

--- a/crates/cli/tests/snapshots/project_templates_tests__readme_content.snap
+++ b/crates/cli/tests/snapshots/project_templates_tests__readme_content.snap
@@ -1,0 +1,5 @@
+---
+source: crates/cli/tests/project_templates_tests.rs
+expression: "ProjectTemplates::readme_content(\"MyProject\")"
+---
+# MyProject

--- a/crates/cli/tests/snapshots/project_templates_tests__spi_content.snap
+++ b/crates/cli/tests/snapshots/project_templates_tests__spi_content.snap
@@ -1,0 +1,9 @@
+---
+source: crates/cli/tests/project_templates_tests.rs
+expression: "ProjectTemplates::spi_content(\"MyLib\")"
+---
+version: 1
+builder:
+  configs:
+    - documentation_targets: [MyLib]
+      scheme: MyLib

--- a/crates/cli/tests/snapshots/project_templates_tests__swift_testing_content.snap
+++ b/crates/cli/tests/snapshots/project_templates_tests__swift_testing_content.snap
@@ -1,0 +1,11 @@
+---
+source: crates/cli/tests/project_templates_tests.rs
+expression: "ProjectTemplates::test_content(\"MyLib\", \"Swift Testing\")"
+---
+import Testing
+@testable import MyLib
+
+@Test func example() {
+    // Swift Testing Documentation
+    // https://developer.apple.com/documentation/testing
+}

--- a/crates/cli/tests/snapshots/project_templates_tests__swiftlint_content.snap
+++ b/crates/cli/tests/snapshots/project_templates_tests__swiftlint_content.snap
@@ -1,0 +1,18 @@
+---
+source: crates/cli/tests/project_templates_tests.rs
+expression: "ProjectTemplates::swiftlint_content()"
+---
+disabled_rules:
+  - trailing_whitespace
+
+vertical_whitespace:
+    severity: error
+
+opt_in_rules:
+  - empty_count
+  - comma
+
+excluded:
+  - Pods
+  - Carthage
+  - Fastlane

--- a/crates/cli/tests/snapshots/project_templates_tests__xctest_content.snap
+++ b/crates/cli/tests/snapshots/project_templates_tests__xctest_content.snap
@@ -1,0 +1,16 @@
+---
+source: crates/cli/tests/project_templates_tests.rs
+expression: "ProjectTemplates::test_content(\"MyLib\", \"XCTest\")"
+---
+import XCTest
+@testable import MyLib
+
+final class MyLibTests: XCTestCase {
+    func testExample() throws {
+        // XCTest Documentation
+        // https://developer.apple.com/documentation/xctest
+
+        // Defining Test Cases and Test Methods
+        // https://developer.apple.com/documentation/xctest/defining_test_cases_and_test_methods
+    }
+}


### PR DESCRIPTION
## ✨ Summary

- add `insta` as a dev-dependency for snapshot-based testing
- replace manual `assert!` / `contains` checks in `project_templates_tests.rs` with `insta::assert_snapshot!` calls
- add generated snapshot files under `crates/cli/tests/snapshots/`
- update `Cargo.lock` with new `insta` and `similar` transitive dependencies

## 🔧 Type of Change

- [ ] ✨ Enhancement
- [ ] 🐞 Bug fix
- [ ] 🔐 Security fix
- [ ] 💥 Breaking change
- [ ] 🚀 New feature
- [ ] 📦 New release
- [ ] 📚 Documentation
- [x] ♻️ Refactor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test code and dev-dependency updates, with no runtime behavior changes. Main risk is increased snapshot maintenance/noise when template output changes.
> 
> **Overview**
> Migrates `project_templates_tests.rs` from manual substring assertions to `insta::assert_snapshot!` snapshot tests, capturing full generated template outputs.
> 
> Adds `insta` as a workspace dependency and as a `dev-dependency` for the CLI crate, and checks in the generated snapshot `.snap` files under `crates/cli/tests/snapshots/`. Updates `Cargo.lock` for the new snapshot-testing dependencies (including `similar`) and bumps several `windows-sys` entries accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cec8f613b6a4ab578a96c37f35f2b485b4bab14a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->