### PR TITLE
refactor: simplify doc comments and optional file dispatch

### DIFF
--- a/crates/cli/src/cli/cli_controller.rs
+++ b/crates/cli/src/cli/cli_controller.rs
@@ -41,7 +41,6 @@ impl Cli {
 	// Internal functions
 
 	/// Prompts the user to input the library or module name
-	/// Validates that the name is not empty
 	fn project_name_input() -> Result<String, SpmError> {
 		let validation_empty = |s: &str| {
 			if s.is_empty() {
@@ -66,7 +65,6 @@ impl Cli {
 	}
 
 	/// Creates a generic multiselect component with a prompt, description, and list of options
-	/// Ensures at least one option is selected before continuing
 	fn multiselect_options(
 		prompt: &str,
 		description: &str,
@@ -121,7 +119,6 @@ impl Cli {
 	}
 
 	/// Displays a select input for platform choice
-	/// The result is always a single selected platform
 	fn select_platform() -> Result<&'static str, SpmError> {
 		let mut select = Select::new("Choose platform")
 			.description("Which platform do you want to choose?")
@@ -160,7 +157,6 @@ impl Cli {
 	}
 
 	/// Shows a loading spinner while running a simulated build step
-	/// Uses a 5 second delay for effect
 	async fn loading() -> Result<(), SpmError> {
 		Spinner::new("Building the Package...")
 			.style(&SpinnerStyle::line())
@@ -171,7 +167,6 @@ impl Cli {
 	}
 
 	/// Asks the user whether to open the generated package in Xcode
-	/// Opens Xcode if confirmed, otherwise returns without opening Xcode
 	fn confirm_open_xcode(project_name: String) -> Result<(), SpmError> {
 		let is_yes = Confirm::new("Do you want to open the package in Xcode?")
 			.affirmative("Yes")

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -4,8 +4,7 @@ pub use cli_controller::Cli;
 use crate::core::error::SpmError;
 use clap::{Parser, Subcommand, ValueEnum};
 
-/// Defines :the CLI arguments accepted by the application
-/// Uses Clap to support a subcommand-based interface
+/// Defines the CLI arguments accepted by the application
 #[derive(Parser)]
 pub struct Args {
 	/// Optional subcommand that defines an alternative execution flow
@@ -14,7 +13,6 @@ pub struct Args {
 }
 
 /// Represents the available CLI subcommands
-/// UI triggers the graphical mode instead of the terminal flow
 #[derive(Subcommand)]
 pub enum Command {
 	/// Runs the UI mode using the iced-based interface

--- a/crates/cli/src/core/file/project_templates.rs
+++ b/crates/cli/src/core/file/project_templates.rs
@@ -9,7 +9,6 @@ impl ProjectTemplates {
 	const SWIFTLINT_PLUGIN_VERSION: &'static str = "0.63.1";
 
 	/// Returns the default Swift source file template
-	/// Used to generate the main `{name}.swift` file inside Sources
 	pub fn project_swift_content() -> Cow<'static, str> {
 		Cow::Borrowed(
 			r#"// The Swift Programming Language
@@ -19,7 +18,6 @@ impl ProjectTemplates {
 	}
 
 	/// Returns the test file template based on the selected framework
-	/// Supports XCTest and Swift Testing
 	pub fn test_content(project_name: &str, test_framework: &str) -> Cow<'static, str> {
 		match test_framework {
 			"Swift Testing" => Cow::Owned(format!(
@@ -53,12 +51,6 @@ final class {name}Tests: XCTestCase {{
 	}
 
 	/// Returns the Package.swift template
-	/// Supports two variants: plugin-enabled or standard package
-	///
-	/// * `project_name` - name of the Swift package
-	/// * `platform` - selected platform such as iOS or macOS
-	/// * `version` - minimum deployment version
-	/// * `is_plugin` - adds SwiftLint plugin configuration when true
 	pub fn package_swift_content(
 		project_name: &str,
 		platform: &str,
@@ -130,7 +122,6 @@ let package = Package(
 	}
 
 	/// Returns the default CHANGELOG.md template
-	/// Used when the Changelog option is selected
 	pub fn changelog_content() -> Cow<'static, str> {
 		Cow::Borrowed(
 			r#"# CHANGELOG
@@ -144,13 +135,11 @@ let package = Package(
 	}
 
 	/// Returns the README.md template
-	/// Includes only the project title by default
 	pub fn readme_content(project_name: &str) -> Cow<'static, str> {
 		Cow::Owned(format!("# {name}\n", name = project_name))
 	}
 
 	/// Returns the .spi.yml template for Swift Package Index configuration
-	/// Defines documentation targets and scheme attributes
 	pub fn spi_content(project_name: &str) -> Cow<'static, str> {
 		Cow::Owned(format!(
 			r#"version: 1
@@ -164,7 +153,6 @@ builder:
 	}
 
 	/// Returns a default SwiftLint configuration template
-	/// Includes baseline rules, opt-in rules, and excluded directories
 	pub fn swiftlint_content() -> Cow<'static, str> {
 		Cow::Borrowed(
 			r#"disabled_rules:

--- a/crates/cli/src/core/platform_validator.rs
+++ b/crates/cli/src/core/platform_validator.rs
@@ -21,8 +21,7 @@ pub trait PlatformGenerator {
 	) -> Result<(), SpmError>;
 }
 
-/// Validates and generates the appropriate platform configuration using the injected
-/// [`PackageCreator`] implementation (the same object as `SpmBuilder`'s file creator).
+/// Validates and generates the appropriate platform configuration
 pub struct PlatformValidator;
 
 impl PlatformGenerator for PlatformValidator {

--- a/crates/cli/src/core/spm_builder.rs
+++ b/crates/cli/src/core/spm_builder.rs
@@ -3,8 +3,6 @@ use crate::core::file::file_creator::FileCreator;
 use crate::core::file::project_file_writer::ProjectFileWriter;
 use crate::core::platform_validator::{PlatformGenerator, PlatformValidator};
 
-type FileHandler<'a> = dyn Fn(&str) -> Result<(), SpmError> + 'a;
-
 /// Builds a Swift Package Manager project using a fluent builder API
 pub struct SpmBuilder<F = ProjectFileWriter, P = PlatformValidator> {
 	file_creator: F,
@@ -71,17 +69,14 @@ impl<F: FileCreator, P: PlatformGenerator> SpmBuilder<F, P> {
 		self.generate_optional_files(name)
 	}
 
-	/// Dispatches optional file creation via a data-driven table
+	/// Creates each optional file that was selected
 	fn generate_optional_files(&self, name: &str) -> Result<(), SpmError> {
-		let handlers: &[(&str, &FileHandler<'_>)] = &[
-			("Changelog", &|n| self.file_creator.create_changelog(n)),
-			("Readme", &|n| self.file_creator.create_readme(n)),
-			("Swift Package Index", &|n| self.file_creator.create_spi(n)),
-		];
-
 		for file in &self.selected_files {
-			if let Some((_, handler)) = handlers.iter().find(|(key, _)| *key == file.as_str()) {
-				handler(name)?;
+			match file.as_str() {
+				"Changelog" => self.file_creator.create_changelog(name)?,
+				"Readme" => self.file_creator.create_readme(name)?,
+				"Swift Package Index" => self.file_creator.create_spi(name)?,
+				_ => {}
 			}
 		}
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -8,7 +8,6 @@ use clap::Parser;
 use cli::Args;
 
 /// Entry point of the application
-/// Uses Tokio runtime to support async operations in the CLI flow
 #[tokio::main]
 async fn main() {
 	let args = Args::parse();


### PR DESCRIPTION
## ✨ Summary

- remove redundant second-line doc comments from CLI and core functions
- fix typo in `Args` doc comment (`Defines :the` → `Defines the`)
- replace data-driven `FileHandler` table in `generate_optional_files` with a simpler `match` expression
- remove unused `FileHandler` type alias from `spm_builder.rs`

## 🔧 Type of Change

- [ ] ✨ Enhancement
- [ ] 🐞 Bug fix
- [ ] 🔐 Security fix
- [ ] 💥 Breaking change
- [ ] 🚀 New feature
- [ ] 📦 New release
- [ ] 📚 Documentation
- [x] ♻️ Refactor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor/documentation cleanup with a small control-flow change in optional file generation; behavior should be equivalent but should be sanity-checked for missed options.
> 
> **Overview**
> Refactors the CLI crate by simplifying/cleaning up doc comments (including fixing a typo in `Args`) across `cli_controller`, `cli/mod`, `project_templates`, `platform_validator`, and `main`.
> 
> In `SpmBuilder`, removes the `FileHandler` dispatch table and replaces optional-file generation with a straightforward `match` over selected file names, dropping the now-unused type alias.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbdb34c386016519cd254e9da3db970a8eb33e44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->