### PR TITLE
chore(deps): track SwiftLintPlugin releases with Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,6 +25,18 @@
       "matchStrings": [
         "channel\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+(\\.\\d+)?)\""
       ]
+    },
+    {
+      "customType": "regex",
+      "depNameTemplate": "lukepistrol/SwiftLintPlugin",
+      "packageNameTemplate": "lukepistrol/SwiftLintPlugin",
+      "datasourceTemplate": "github-releases",
+      "managerFilePatterns": [
+        "/(^|/)crates/cli/src/core/file/project_templates\\.rs$/"
+      ],
+      "matchStrings": [
+        "SWIFTLINT_PLUGIN_VERSION:\\s*&'static str = \"(?<currentValue>[^\"]+)\""
+      ]
     }
   ]
 }


### PR DESCRIPTION
## ✨ Summary

- add Renovate customManager to track SwiftLintPlugin releases via github-releases datasource
- extend regex matching to SWIFTLINT_PLUGIN_VERSION constant in project_templates.rs

## 🔧 Type of Change

- [ ] ✨ Enhancement
- [ ] 🐞 Bug fix
- [ ] 🔐 Security fix
- [ ] 💥 Breaking change
- [ ] 🚀 New feature
- [ ] 📦 New release
- [ ] 📚 Documentation
- [ ] ♻️ Refactor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change to Renovate; no runtime or application logic is modified.
> 
> **Overview**
> Adds a **Renovate regex custom manager** so `SWIFTLINT_PLUGIN_VERSION` in `project_templates.rs` is kept in sync with **GitHub releases** for `lukepistrol/SwiftLintPlugin`, using the same pattern as the existing Rust toolchain entry in `renovate.json`.
> 
> Renovate will open dependency update PRs when a new SwiftLintPlugin release is published, without manual version bumps in the CLI project templates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7afe2f9bae26d5db98d0ac706a8174e44d43e352. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->