### PR TITLE
fix(renovate): remove duplicate version from commit message topic

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,7 @@
   ],
   "commitMessagePrefix": "chore(deps):",
   "commitMessageAction": "update",
-  "commitMessageTopic": "{{depName}} to v{{newVersion}}",
+  "commitMessageTopic": "{{depName}}",
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## ✨ Summary

- remove redundant "to v{{newVersion}}" from Renovate's commitMessageTopic
- fixes duplicated version in PR titles (e.g. "update X to v0.65.0 to v0.65.0")

## 🔧 Type of Change

- [ ] ✨ Enhancement
- [x] 🐞 Bug fix
- [ ] 🔐 Security fix
- [ ] 💥 Breaking change
- [ ] 🚀 New feature
- [ ] 📦 New release
- [ ] 📚 Documentation
- [ ] ♻️ Refactor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to Renovate commit message formatting; no runtime or application code affected.
> 
> **Overview**
> Renovate’s **`commitMessageTopic`** in `.github/renovate.json` is narrowed from `{{depName}} to v{{newVersion}}` to **`{{depName}}` only**.
> 
> With the existing **`commitMessageAction`** (`update`) and default Renovate templates, the old topic duplicated the target version in PR/commit titles (e.g. “update foo to v0.65.0 to v0.65.0”). Future dependency bump PRs should show a single version in the title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c788b32823496d471768c9c369c44ac42af95bca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->